### PR TITLE
Control nutshutdown script removal with a flag

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 nut_host: localhost
 nut_max_retry: 3
 nut_mode: netserver
+nut_remove_shutdown_script: true
 
 nut_user_master_name: monuser
 nut_user_master_password: monpassword

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,4 +35,4 @@
   file:
     path: /lib/systemd/system-shutdown/nutshutdown
     state: absent
-  when: nut_remove_shutdown_script == true
+  when: nut_remove_shutdown_script

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,3 +35,4 @@
   file:
     path: /lib/systemd/system-shutdown/nutshutdown
     state: absent
+  when: nut_remove_shutdown_script == true


### PR DESCRIPTION
It'd be handy to have the shutdown script removal controlled with a flag, it's required when using this role on a non virtualised host directly connected to a UPS.